### PR TITLE
Merge latest upstream

### DIFF
--- a/lambda/take_snapshots_rds/lambda_function.py
+++ b/lambda/take_snapshots_rds/lambda_function.py
@@ -46,7 +46,7 @@ def lambda_handler(event, context):
     now = datetime.now()
     pending_backups = 0
     filtered_instances = filter_instances(TAGGEDINSTANCE, PATTERN, response)
-    filtered_snapshots = get_own_snapshots_source(PATTERN, paginate_api_call(client, 'describe_db_snapshots', 'DBSnapshots'))
+    filtered_snapshots = get_own_snapshots_source(PATTERN, paginate_api_call(client, 'describe_db_snapshots', 'DBSnapshots'), BACKUP_INTERVAL)
 
     for db_instance in filtered_instances:
 


### PR DESCRIPTION
Sharing rds snapshots has been failing occasionally lately:
```
An error occurred (Throttling) when calling the ListTagsForResource operation (reached max retries: 4): Rate exceeded: ClientError
Traceback (most recent call last):
File "/var/task/lambda_function.py", line 44, in lambda_handler
filtered = get_own_snapshots_source(PATTERN, response)
File "/var/task/snapshots_tool_utils.py", line 213, in get_own_snapshots_source
ResourceName=snapshot['DBSnapshotArn'])
File "/var/runtime/botocore/client.py", line 314, in _api_call
return self._make_api_call(operation_name, kwargs)
File "/var/runtime/botocore/client.py", line 612, in _make_api_call
raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (Throttling) when calling the ListTagsForResource operation (reached max retries: 4): Rate exceeded
```

This is supposed to be fixed upstream https://github.com/awslabs/rds-snapshot-tool/pull/26/files
This PR is to merge upstream changes.